### PR TITLE
fix: add `GenericRocks` dep and use `Granite` from there

### DIFF
--- a/assets/blocks/mineral/GraniteGrimstad.block
+++ b/assets/blocks/mineral/GraniteGrimstad.block
@@ -3,6 +3,6 @@
  * It is a reddish pink in color, with dark speckles.
  */
 {
-    "basedOn": "Minerals:Granite",
+    "basedOn": "GenericRocks:Granite",
     "displayName": "Grimstad Granite"
 }

--- a/module.txt
+++ b/module.txt
@@ -5,9 +5,9 @@
     "displayName": "Mineral Pack",
     "description": "This module adds a wide range of minerals.",
     "dependencies": [
-        { "id": "CoreAssets", "minVersion": "2.0.1" }
+        { "id": "CoreAssets", "minVersion": "2.0.1" },
+        { "id": "GenericRocks", "minVersion": "1.0.0" }
     ],
     "isServerSideOnly": false,
-    "isAsset": true,
-    "isWorld": true
+    "isAsset": true
 }


### PR DESCRIPTION
- Granite is used as parent for `GraniteGrimstad` but was move into `GenericRocks` a while ago